### PR TITLE
Change bundler version to 2.0.1

### DIFF
--- a/lib/language_pack/helpers/bundler_wrapper.rb
+++ b/lib/language_pack/helpers/bundler_wrapper.rb
@@ -37,7 +37,7 @@ class LanguagePack::Helpers::BundlerWrapper
 
   BLESSED_BUNDLER_VERSIONS = {}
   BLESSED_BUNDLER_VERSIONS["1"] = "1.15.2"
-  BLESSED_BUNDLER_VERSIONS["2"] = "2.0.2"
+  BLESSED_BUNDLER_VERSIONS["2"] = "2.0.1"
   private_constant :BLESSED_BUNDLER_VERSIONS
 
   class GemfileParseError < BuildpackError


### PR DESCRIPTION
#### Background

This repo is a temporary measure as we migrate over to Heroku from Cloud Foundry.

CF does not currently support the 2.0.2 bundler, and therefore to ensure our builds are successful over **both platforms** we need to ensure Heroku also uses the 2.0.1 bundler.

#### Solution

This fork of the default `heroku-buildpack-ruby` has had the Bundler version changed to ensure that this is the case.